### PR TITLE
Fix cBytes calculation in TabixIndexedFile.records

### DIFF
--- a/src/io/TabixIndexedFile.js
+++ b/src/io/TabixIndexedFile.js
@@ -485,8 +485,8 @@ class TabixIndexedFile {
       return Promise.all(chunks.map((chunk) => {
         // At a minimum read at least one compressed block (which must be less than 64k)
         const cOffset = chunk.beg.coffset;
-        const cBytes = (chunk.end.coffset - chunk.beg.coffset)
-          + (chunk.end.uoffset > 0) ? 65536 : 0;
+        const cBytes = chunk.end.coffset - chunk.beg.coffset
+          + (chunk.end.uoffset > 0 ? 65536 : 0);
 
         return this._source.bytes(cOffset, cBytes).then((buffer) => {
           const uOffset = chunk.beg.uoffset; // Start decoding at chunk's uncompressed offset


### PR DESCRIPTION
The ternary operator binds more tightly than addition.

I've not attempted to make a test for this yet. The bug occured when requesting an interval spanning more than one block.