### PR TITLE
Use global TextDecoder and target node 12 saving 650kB from bundle size.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "presets": [
     "@babel/preset-flow",
-    ["@babel/preset-env", { "forceAllTransforms": true }]
+    ["@babel/preset-env", { "targets": { "node": 12 } }]
   ],
   "plugins": ["@babel/plugin-proposal-class-properties"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "lts/carbon"
+  - "12"
 dist: trusty
 sudo: false
 addons:

--- a/package-lock.json
+++ b/package-lock.json
@@ -8344,11 +8344,6 @@
         }
       }
     },
-    "text-encoding": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.7.0.tgz",
-      "integrity": "sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA=="
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint .",
     "prepare": "babel src/ -d lib --ignore test.js"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "files": [
     "lib",
     "dist"
@@ -60,8 +63,7 @@
     "jdataview": "^2.5.0",
     "lodash": "^4.17.11",
     "pako": "^1.0.10",
-    "promise-defer": "^1.0.0",
-    "text-encoding": "^0.7.0"
+    "promise-defer": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/io/TabixIndexedFile.js
+++ b/src/io/TabixIndexedFile.js
@@ -46,7 +46,6 @@
 const jDataView = require('jdataview');
 const jBinary = require('jbinary');
 const pako = require('pako/lib/inflate');
-const { TextDecoder } = require('text-encoding');
 const defer = require('promise-defer');
 const findLastIndex = require('lodash/findLastIndex');
 const { ContigNotInIndexError } = require('../util/Errors');


### PR DESCRIPTION
Modern browsers support TextDecoder natively. While Node added it as util.TextDecoder in Node 8, it didn't become a global until Node 12.

Unfortunately the [browserify util module](https://www.npmjs.com/package/util) does not currently support it making it difficult to use `require('util').TextDecoder` from a bundler. It may be preferable to support Node back to 8 and use:
```js
const TextDecoder = global.TextDecoder || require('util').TextDecoder;
```